### PR TITLE
Bump Phoenix / Calliope Versions

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule PhoenixHaml.Mixfile do
 
   defp deps do
     [
-      {:phoenix, github: "phoenixframework/phoenix"},
+      {:phoenix, "~> 0.8.0"},
       {:cowboy, "~> 1.0.0", only: [:dev, :test]},
       {:calliope, "~> 0.2.7"}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -24,9 +24,9 @@ defmodule PhoenixHaml.Mixfile do
 
   defp deps do
     [
-      {:phoenix, "~> 0.8.0"},
+      {:phoenix, "~> 0.11.0"},
       {:cowboy, "~> 1.0.0", only: [:dev, :test]},
-      {:calliope, "~> 0.2.7"}
+      {:calliope, "~> 0.3.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,7 @@
-%{"calliope": {:hex, :calliope, "0.2.7"},
+%{"calliope": {:hex, :calliope, "0.3.0"},
   "cowboy": {:hex, :cowboy, "1.0.0"},
-  "cowlib": {:hex, :cowlib, "1.0.0"},
-  "linguist": {:hex, :linguist, "0.1.2"},
-  "phoenix": {:git, "git://github.com/phoenixframework/phoenix.git", "8cffae4744e30e06e6770b4170e2884edd09a85f", []},
-  "plug": {:hex, :plug, "0.8.1"},
-  "poison": {:hex, :poison, "1.2.0"},
+  "cowlib": {:hex, :cowlib, "1.0.1"},
+  "phoenix": {:hex, :phoenix, "0.11.0"},
+  "plug": {:hex, :plug, "0.11.3"},
+  "poison": {:hex, :poison, "1.4.0"},
   "ranch": {:hex, :ranch, "1.0.0"}}

--- a/test/phoenix_haml_test.exs
+++ b/test/phoenix_haml_test.exs
@@ -2,29 +2,22 @@ defmodule PhoenixHamlTest do
   use ExUnit.Case
   alias Phoenix.View
 
-
-  defmodule MyApp.View do
+  defmodule MyApp.PageView do
     use Phoenix.View, root: "test/fixtures/templates"
 
-    using do
-      use Phoenix.HTML
-    end
-  end
-
-  defmodule MyApp.PageView do
-    use MyApp.View
+    use Phoenix.HTML
   end
 
   test "render a haml template with layout" do
     html = View.render(MyApp.PageView, "new.html",
       message: "hi",
-      within: {MyApp.PageView, "application.html"}
+      layout: {MyApp.PageView, "application.html"}
     )
-    assert html == {:safe, "<html><body><h2>New Template</h2></body></html>"}
+    assert html == {:safe, [[["" | "<html><body>"], "" | "<h2>New Template</h2>"] | "</body></html>"]}
   end
 
   test "render a haml template without layout" do
     html = View.render(MyApp.PageView, "new.html", [])
-    assert html == {:safe, "<h2>New Template</h2>"}
+    assert html == {:safe, ["" | "<h2>New Template</h2>"]}
   end
 end


### PR DESCRIPTION
This patch bumps the version of Phoenix to 0.11.0 and Calliope to 0.3.0. I adjusted the test cases to fit these new expectations.

The `phoenix_ham/master` branch currently tracks `phoenix/master`, but should probably choose a version of phoenix. Alternatively, this can be done on branches/tags of `phoenix_haml/master` and pushed to Hex from that separate branch/tag.