### PR TITLE
Match changes in Phoenix for Phoenix.Template.HTML to use correct engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Usage
 
-  1. Add `{:phoenix_haml, "~> 0.0.5"}` to your deps in `mix.exs`.
+  1. Add `{:phoenix_haml, "~> 0.1.0"}` to your deps in `mix.exs`.
      If you generated your app from the Phoenix master branch,
      add phoenix_haml's master branch to your deps instead.
      `{:phoenix_haml, github: "chrismccord/phoenix_haml"}`
@@ -15,3 +15,5 @@
   config :phoenix, :template_engines,
     haml: PhoenixHaml.Engine
 ```
+
+  3. Add templates to your project with the extension `.html.haml`, e.g. (`app/templates/page/home.html.haml`).

--- a/lib/phoenix_haml/engine.ex
+++ b/lib/phoenix_haml/engine.ex
@@ -16,8 +16,15 @@ defmodule PhoenixHaml.Engine do
 
   defp engine_for(name) do
     case Phoenix.Template.format_encoder(name) do
-      Phoenix.HTML.Engine -> Phoenix.HTML.Engine
-      _                   -> EEx.SmartEngine
+      Phoenix.Template.HTML ->
+        unless Code.ensure_loaded?(Phoenix.HTML.Engine) do
+          raise "Could not load Phoenix.HTML.Engine to use with .html.haml templates. " <>
+                "You can configure your own format encoder for HTML but we recommend " <>
+                "adding phoenix_html as a dependency as it provides XSS protection."
+        end
+        Phoenix.HTML.Engine
+      _ ->
+        EEx.SmartEngine
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,8 @@ defmodule PhoenixHaml.Mixfile do
 
   defp deps do
     [
-      {:phoenix, "~> 0.12.0"},
+      {:phoenix, "~> 0.13.1"},
+      {:phoenix_html, "~> 1.0"},
       {:cowboy, "~> 1.0.0", only: [:dev, :test]},
       {:calliope, "~> 0.3.0"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,8 @@
 %{"calliope": {:hex, :calliope, "0.3.0"},
   "cowboy": {:hex, :cowboy, "1.0.0"},
   "cowlib": {:hex, :cowlib, "1.0.1"},
-  "phoenix": {:hex, :phoenix, "0.12.0"},
+  "phoenix": {:hex, :phoenix, "0.13.1"},
+  "phoenix_html": {:hex, :phoenix_html, "1.0.1"},
   "plug": {:hex, :plug, "0.12.2"},
   "poison": {:hex, :poison, "1.4.0"},
   "ranch": {:hex, :ranch, "1.0.0"}}


### PR DESCRIPTION
To match [this commit in Phoenix](https://github.com/phoenixframework/phoenix/commit/0954a4f8#diff-769b08b614708992cbdbbb417921a7e8R15), phoenix_haml needs to check against `Phoenix.Template.HTML` for which engine to use. Without this patch, HAML templates are coming up as escaped HTML when run against Phoenix 0.13.x.

This patch also updates the version of Phoenix to `~> 0.13.1`, adds `Phoenix.HTML` as a dependency and reflects its current version in `README.md`.