### PR TITLE
Remove Cowboy dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,6 @@ defmodule PhoenixHaml.Mixfile do
     [
       {:phoenix, "~> 1.0.0"},
       {:phoenix_html, "~> 2.1"},
-      {:cowboy, "~> 1.0.0", only: [:dev, :test]},
       {:calliope, "~> 0.3.0"}
     ]
   end


### PR DESCRIPTION
This avoids getting the error message

```
Unchecked dependencies for environment test:
* cowboy (Hex package)
  the dependency cowboy

  > In mix.exs:
    {:cowboy, "~> 1.0.0", [hex: :cowboy, only: [:dev, :test]]}

  does not match the environments calculated for

  > In deps/phoenix/mix.exs:
    {:cowboy, "~> 1.0", [optional: true, hex: :cowboy]}

  Remove the :only restriction from your dep
** (Mix) Can't continue due to errors on dependencies
```

when running `mix.test`