### PR TITLE
Relax phoenix dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,6 @@ defmodule PhoenixHaml.Mixfile do
     [
       {:phoenix, "~> 1.0.0"},
       {:phoenix_html, "~> 2.1"},
-      {:cowboy, "~> 1.0.0", only: [:dev, :test]},
       {:calliope, "~> 0.3.0"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule PhoenixHaml.Mixfile do
 
   defp deps do
     [
-      {:phoenix, "~> 1.0.0"},
+      {:phoenix, "~> 1.0"},
       {:phoenix_html, "~> 2.1"},
       {:calliope, "~> 0.3.0"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
 %{"calliope": {:hex, :calliope, "0.3.0"},
   "cowboy": {:hex, :cowboy, "1.0.2"},
   "cowlib": {:hex, :cowlib, "1.0.1"},
-  "phoenix": {:hex, :phoenix, "1.0.0"},
+  "phoenix": {:hex, :phoenix, "1.1.0"},
   "phoenix_html": {:hex, :phoenix_html, "2.2.0"},
-  "plug": {:hex, :plug, "1.0.0"},
+  "plug": {:hex, :plug, "1.0.3"},
   "poison": {:hex, :poison, "1.5.0"},
   "ranch": {:hex, :ranch, "1.1.0"}}

--- a/test/fixtures/templates/my_app/page/application.html.haml
+++ b/test/fixtures/templates/my_app/page/application.html.haml
@@ -1,4 +1,4 @@
 %html
   %body
-    = @inner
+    = render @view_module, @view_template, assigns
 


### PR DESCRIPTION
Allows for using `phoenix_haml` with Phoenix 1.1

In order to test this, I had to remove the direct cowboy dependency; so this PR also includes #20 