### PR TITLE
Update to phoenix 1.1 and phoenix_html 2.3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PhoenixHaml.Mixfile do
   def project do
     [
       app: :phoenix_haml,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.0.1 or ~> 1.1",
       deps: deps,
       package: [
@@ -24,8 +24,8 @@ defmodule PhoenixHaml.Mixfile do
 
   defp deps do
     [
-      {:phoenix, "~> 1.0"},
-      {:phoenix_html, "~> 2.1"},
+      {:phoenix, "~> 1.1"},
+      {:phoenix_html, "~> 2.3"},
       {:calliope, "~> 0.3.0"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "cowboy": {:hex, :cowboy, "1.0.2"},
   "cowlib": {:hex, :cowlib, "1.0.1"},
   "phoenix": {:hex, :phoenix, "1.1.0"},
-  "phoenix_html": {:hex, :phoenix_html, "2.2.0"},
+  "phoenix_html": {:hex, :phoenix_html, "2.3.0"},
   "plug": {:hex, :plug, "1.0.3"},
   "poison": {:hex, :poison, "1.5.0"},
   "ranch": {:hex, :ranch, "1.1.0"}}


### PR DESCRIPTION
Heroku build pack https://github.com/HashNuke/heroku-buildpack-elixir
does not allow pulling deps from github repos, so I need this update before I can use haml.
The doc of the heroku buildpack says I can only use precompiled binaries. It would be great if I could point to the head of a repo.