### PR TITLE
Add extension info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
     config :phoenix, :template_engines,
       haml: PhoenixHaml.Engine
      ```
-  3. Use the `.html.haml` extensions for your templates
+  3. Use the `.html.haml` extensions for your templates.
 
 ## Optional
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@
      If you generated your app from the Phoenix master branch,
      add phoenix_haml's master branch to your deps instead.
      `{:phoenix_haml, github: "chrismccord/phoenix_haml"}`
-  2. Add the following your Phoenix `config/config.exs`
+  2. Add the following to your Phoenix `config/config.exs`
 
-```elixir
-config :phoenix, :template_engines,
-  haml: PhoenixHaml.Engine
-```
+     ```elixir
+    config :phoenix, :template_engines,
+      haml: PhoenixHaml.Engine
+     ```
+  3. Use the `.html.haml` extensions for your templates
 
 ## Optional
 


### PR DESCRIPTION
I found it confusing not knowing whether `page.haml` would work, like it does with the `haml` gem. It doesn't, so I documented it here.