### PR TITLE
added filename to CalliopeException message

### DIFF
--- a/lib/phoenix_haml/engine.ex
+++ b/lib/phoenix_haml/engine.ex
@@ -11,6 +11,16 @@ defmodule PhoenixHaml.Engine do
   end
 
   defp read!(file_path) do
-    file_path |> File.read! |> Calliope.Render.precompile
+    try do
+      file_path |> File.read! |> Calliope.Render.precompile
+    rescue
+      exception ->
+        case exception do
+          %CalliopeException{message: message} ->
+            reraise %CalliopeException{message: "#{file_path}: " <> message}, System.stacktrace
+          _ ->
+            reraise exception, System.stacktrace
+        end
+    end
   end
 end


### PR DESCRIPTION
When Calliope raises an exception, the filename being parsed is not available in the exception message and stack trace. Since Calliope does not know the filename, it cannot display this information. So, this change adds the file path to the CalliopeException message. 