### PR TITLE
Removes `()` ambiguity warning from mix file

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule PhoenixHaml.Mixfile do
       app: :phoenix_haml,
       version: "0.2.2",
       elixir: "~> 1.0.1 or ~> 1.1",
-      deps: deps,
+      deps: deps(),
       package: [
         contributors: ["Chris McCord", "Stephen Pallen"],
         maintainers: ["Chris McCord", "Stephen Pallen"],


### PR DESCRIPTION
With the new release of Elixir 1.4 we there is a warning for using a zero
argument method without parentheses. Adding in the parenthesis to
remove the warning.

Amos King @adkron <amos@binarynoggin.com>