### PR TITLE
Allowing for phoenix rc releases

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule PhoenixHaml.Mixfile do
 
   defp deps do
     [
-      {:phoenix, "~> 1.1"},
+      {:phoenix, "~> 1.1 or ~> 1.1-rc"},
       {:phoenix_html, "~> 2.3"},
       {:calliope, "~> 0.4.1"}
     ]


### PR DESCRIPTION
Had difficulty with running this with phoenix 1.3-rc. got this error:

```
Failed to use "phoenix" (version 1.3.0-rc.0) because
  phoenix_haml (version 0.2.3) requires ~> 1.1 *
```

It suggested adding `override: true`but it didn't do anything. This PR just adds `rc` bit that allows install to work.